### PR TITLE
Resolve makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX ?= /usr
+PREFIX ?= /usr/local
 BIN ?= /bin
 DATA ?= /share
 BINDIR ?= $(PREFIX)$(BIN)


### PR DESCRIPTION
I'm changing the default prefix to `/usr/local` as this isn't an application that's being installed via a system package manager, as well as removing the extra line breaks in the Makefile.
